### PR TITLE
fix duplicate error caused by removing story once it is matched

### DIFF
--- a/storygraph_bot/backbone.py
+++ b/storygraph_bot/backbone.py
@@ -58,16 +58,15 @@ def mapper(overlap_threshold, cachedstories_uri_dts, stories_uri_dts, cache_stor
 
         overlap = sorted(overlap, key=lambda x: x['coeff'], reverse=True)
         maxcoeff = overlap[0]['coeff']
-        chosensgtk_story_id = overlap[0]['sgtk_story_id']
-
-        if maxcoeff >= overlap_threshold:                 
+        
+        if maxcoeff >= overlap_threshold: 
+            chosensgtk_story_id = overlap[0]['sgtk_story_id']                
             new_graphs = sorted(list(stories_uri_dts[chosensgtk_story_id] - cs_uridt), reverse=True)
             matched_stories.update({story_id: {'overlap': overlap, "new_graph_timestamps": new_graphs}})
+            stories_uri_dts[chosensgtk_story_id] = set()            
         else:
             unmatched_stories.update({story_id: {'overlap': overlap}})
         
-        stories_uri_dts[chosensgtk_story_id] = set()            
-
     map_cachestories["matched_stories"] = matched_stories
     map_cachestories["unmatched_stories"] = unmatched_stories
     return(map_cachestories)

--- a/storygraph_bot/util.py
+++ b/storygraph_bot/util.py
@@ -145,13 +145,12 @@ def dump_json_to_file(outfilename, dict_to_write, indent_flag=True, extra_params
 
 
 
-def get_storygraph_stories(sgbot_path, start_datetime, end_datetime):
-    
+def get_storygraph_stories(sgbot_path, start_datetime, end_datetime):   
     data = {}
     try:
         cmd = (f'sgtk --pretty-print -o {sgbot_path}/tmp/current_storygraphdata.json maxgraph --cluster-stories-by="max_avg_degree" --cluster-stories --start-datetime="{start_datetime}" --end-datetime="{end_datetime}" > {sgbot_path}/tmp/console_output.log  2>&1')
         a = os.system(cmd)
-        data = get_dict_frm_file( f"{sgbot_path}/tmp/current_storygraphdata.json" )
+        data = get_dict_frm_file(f'{sgbot_path}/tmp/current_storygraphdata.json')
     except FileNotFoundError as e:
         logger.error('Please install storygraph-toolkit: https://github.com/oduwsdl/storygraph-toolkit.git')
     


### PR DESCRIPTION
Fix the error that was causing duplicate stories.

The problem was with the fix that we did earlier. We removed the story once it was matched so that the story won't be matched again with another. for example we have storyID_1 which matches with sgtk-story-0.  then let's say storyID_2 also matches sgtk-story-0. so we remove sgtk-story-0 after the first match, so it will only match once (with storyID_1).

The problem was that since the code was placed outside the condition, it was removing the story even if it was unmatched, hence we were getting "0" overlap.